### PR TITLE
Fix intermittent UI test SocketTimeoutExceptions on slow runners

### DIFF
--- a/src/test/kotlin/com/github/uiopak/lstcrc/plugin/utils/RemoteRobotExtension.kt
+++ b/src/test/kotlin/com/github/uiopak/lstcrc/plugin/utils/RemoteRobotExtension.kt
@@ -42,12 +42,24 @@ class RemoteRobotExtension : AfterTestExecutionCallback, ParameterResolver {
         }
         val client = OkHttpClient.Builder().apply {
             this.addInterceptor(interceptor)
+            this.connectTimeout(connectionTimeout)
+            this.readTimeout(connectionTimeout)
+            this.writeTimeout(connectionTimeout)
         }.build()
         RemoteRobot(url, client)
     } else {
-        RemoteRobot(url)
+        val client = OkHttpClient.Builder().apply {
+            this.connectTimeout(connectionTimeout)
+            this.readTimeout(connectionTimeout)
+            this.writeTimeout(connectionTimeout)
+        }.build()
+        RemoteRobot(url, client)
     }
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder().apply {
+        this.connectTimeout(connectionTimeout)
+        this.readTimeout(connectionTimeout)
+        this.writeTimeout(connectionTimeout)
+    }.build()
 
     override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean {
         return parameterContext.parameter.type == RemoteRobot::class.java


### PR DESCRIPTION
Fix UI test read timeouts on slow runners by configuring OkHttpClient correctly with connectionTimeout.

---
*PR created automatically by Jules for task [904403220221996509](https://jules.google.com/task/904403220221996509) started by @uiopak*